### PR TITLE
stricter conversion for @attributes and #text

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -69,5 +69,12 @@ class TestXmlutils(unittest.TestCase):
         expected = '<xml><flag>true</flag><foo>bar</foo><baz>baz1</baz><baz>baz2</baz></xml>'
         self.assertEqual(expected, dict_to_xml(dict_xml))
 
+        dict_xml = {'xml': 
+            {'foo': 'bar', 'baz': [{'baz1': 'baz2'}, {'baz1':'baz2', '@baz':
+                'baz'}], '@qux': 'qux'}
+        }
+        expected = '<xml qux="qux"><foo>bar</foo><baz><baz1>baz2</baz1></baz><baz baz="baz"><baz1>baz2</baz1></baz></xml>'
+        self.assertEqual(expected, dict_to_xml(dict_xml))
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -156,10 +156,16 @@ class TestXmlutils(unittest.TestCase):
         self.assertEqual(expected, dict_to_xml(dict_xml))
 
         dict_xml = {'xml': 
-            {'foo': 'bar', 'baz': [{'baz1': 'baz2'}, {'baz1':'baz2', '@baz':
-                'baz'}], '@qux': 'qux'}
+            {'foo': 'bar', 'baz': [
+                {'baz1': 'baz2'}, 
+                {'baz1':'baz2', '@baz':'baz'},
+                {'baz3': {'@baz3':'baz3', '#text':'bazbaz'}}
+            ], 
+            '@qux': 'qux', 
+            'doo': {'@doo1': 'doo1', '#text': 'doodoo'}
+            }
         }
-        expected = '<xml qux="qux"><foo>bar</foo><baz><baz1>baz2</baz1></baz><baz baz="baz"><baz1>baz2</baz1></baz></xml>'
+        expected = '<xml qux="qux"><foo>bar</foo><baz><baz1>baz2</baz1></baz><baz baz="baz"><baz1>baz2</baz1></baz><baz><baz3 baz3="baz3">bazbaz</baz3></baz><doo doo1="doo1">doodoo</doo></xml>'
         self.assertEqual(expected, dict_to_xml(dict_xml))
 
 if __name__ == '__main__':

--- a/tests.py
+++ b/tests.py
@@ -60,6 +60,92 @@ class TestXmlutils(unittest.TestCase):
 
         self.assertEqual(expected, xml_to_dict(test))
 
+    def test_xml_to_dict_strict(self):
+        test = '''
+        <payment_method>
+        <payment_method_token>QhLaMNNpvHwfnFbHbUYhNxadx4C</payment_method_token>
+        <created_at type="datetime">2011-02-12T20:20:46Z</created_at>
+        <updated_at type="datetime">2011-04-22T17:57:30Z</updated_at>
+        <custom>Any value you want us to save with this payment method.</custom>
+        <is_retained type="boolean">true</is_retained>
+        <is_redacted type="boolean">false</is_redacted>
+        <is_sensitive_data_valid type="boolean">false</is_sensitive_data_valid>
+        <messages>
+            <message class="error" context="input.cvv" key="too_long" />
+            <message class="error" context="input.card_number" key="failed_checksum" />
+        </messages>
+        <last_four_digits>1111</last_four_digits>
+        <card_type>visa</card_type>
+        <first_name>Bob</first_name>
+        <last_name>Smith</last_name>
+        <expiry_month type="integer">1</expiry_month>
+        <expiry_year type="integer">2020</expiry_year>
+        <address_1 nil="true"></address_1>
+        <address_2 nil="true"></address_2>
+        <city nil="true"></city>
+        <state nil="true"></state>
+        <zip nil="true"></zip>
+        <country nil="true"></country>
+        </payment_method>
+        '''
+
+        expected = {'payment_method': {'address_1': {'@nil': 'true'},
+        'address_2': {'@nil': 'true'},
+        'card_type': 'visa',
+        'city': {'@nil': 'true'},
+        'country': {'@nil': 'true'},
+        'created_at': {
+            '@type': 'datetime',
+            '#value': datetime.datetime(2011, 2, 12, 20, 20, 46),
+            '#text': '2011-02-12T20:20:46Z'
+        },
+        'custom': 'Any value you want us to save with this payment method.',
+        'expiry_month': {
+            '@type': 'integer',
+            '#value': 1,
+            '#text': '1'
+        },
+        'expiry_year': {
+            '@type': 'integer',
+            '#value': 2020,
+            '#text': '2020'
+        },
+        'first_name': 'Bob',
+        'is_redacted': {
+            '@type': 'boolean',
+            '#value': False,
+            '#text': 'false'
+        },
+        'is_retained': {
+            '@type': 'boolean',
+            '#value': True,
+            '#text': 'true'
+        },
+        'is_sensitive_data_valid': {
+            '@type':'boolean',
+            '#value': False,
+            '#text': 'false'
+        },
+        'last_four_digits': '1111',
+        'last_name': 'Smith',
+        'messages': {'message': [{'@class': 'error',
+            '@context': 'input.cvv',
+            '@key': 'too_long'},
+            {'@class': 'error',
+            '@context': 'input.card_number',
+            '@key': 'failed_checksum'}]},
+        'payment_method_token': 'QhLaMNNpvHwfnFbHbUYhNxadx4C',
+        'state': {'@nil': 'true'},
+        'updated_at': {
+            '@type': 'datetime',
+            '#value': datetime.datetime(2011, 4, 22, 17, 57, 30),
+            '#text': '2011-04-22T17:57:30Z'
+        },
+        'zip': {'@nil': 'true'}}}
+
+        self.assertEqual(expected, xml_to_dict(test, True))
+
+
     def test_dict_to_xml(self):
         dict_xml = {'transaction': {'amount': '100.00', 'currency_code': 'USD'}}
         expected = '<transaction><amount>100.00</amount><currency_code>USD</currency_code></transaction>'

--- a/xmldict.py
+++ b/xmldict.py
@@ -40,15 +40,30 @@ def _to_xml(el):
         val = el
     return val
 
+def _extract_attrs(els):
+    attrs = ' '.join([
+        '%s="%s"' % (key[1:], value) for (
+            key, value) in els.items() if key.startswith('@')
+    ])
+
+    return attrs
+
 def _dict_to_xml(els):
     """
     Converts `els` which is a python dict to corresponding xml.
     """
     tags = []
     for tag, content in els.iteritems():
+        if tag.startswith('@'):
+            continue
+
         if isinstance(content, list):
             for el in content:
-                tags.append('<%s>%s</%s>' % (tag, _to_xml(el), tag))
+                attrs = _extract_attrs(el)
+                tags.append('<%s %s>%s</%s>' % (tag, attrs, _to_xml(el), tag))
+        elif isinstance(content, dict):
+            attrs = _extract_attrs(content)
+            tags.append('<%s %s>%s</%s>' % (tag, attrs, _to_xml(content), tag))
         else:
             tags.append('<%s>%s</%s>' % (tag, _to_xml(content), tag))
     return ''.join(tags)

--- a/xmldict.py
+++ b/xmldict.py
@@ -59,6 +59,7 @@ def _dict_to_xml(els):
     for tag, content in els.iteritems():
         if tag.startswith('@'):
             continue
+        if tag == '#text': continue
 
         if isinstance(content, list):
             for el in content:
@@ -66,7 +67,10 @@ def _dict_to_xml(els):
                 tags.append('<%s%s>%s</%s>' % (tag, attrs, _to_xml(el), tag))
         elif isinstance(content, dict):
             attrs = _extract_attrs(content)
-            tags.append('<%s%s>%s</%s>' % (tag, attrs, _to_xml(content), tag))
+            text = ''
+            if content.has_key('#text'):
+                text = content['#text']
+            tags.append('<%s%s>%s%s</%s>' % (tag, attrs, _to_xml(content), text, tag))
         else:
             tags.append('<%s>%s</%s>' % (tag, _to_xml(content), tag))
     return ''.join(tags)

--- a/xmldict.py
+++ b/xmldict.py
@@ -41,8 +41,11 @@ def _to_xml(el):
     return val
 
 def _extract_attrs(els):
-    attrs = ' '.join([
-        '%s="%s"' % (key[1:], value) for (
+    if not isinstance(els, dict):
+        return ''
+
+    attrs = ''.join([
+        ' %s="%s"' % (key[1:], value) for (
             key, value) in els.items() if key.startswith('@')
     ])
 
@@ -60,10 +63,10 @@ def _dict_to_xml(els):
         if isinstance(content, list):
             for el in content:
                 attrs = _extract_attrs(el)
-                tags.append('<%s %s>%s</%s>' % (tag, attrs, _to_xml(el), tag))
+                tags.append('<%s%s>%s</%s>' % (tag, attrs, _to_xml(el), tag))
         elif isinstance(content, dict):
             attrs = _extract_attrs(content)
-            tags.append('<%s %s>%s</%s>' % (tag, attrs, _to_xml(content), tag))
+            tags.append('<%s%s>%s</%s>' % (tag, attrs, _to_xml(content), tag))
         else:
             tags.append('<%s>%s</%s>' % (tag, _to_xml(content), tag))
     return ''.join(tags)

--- a/xmldict.py
+++ b/xmldict.py
@@ -6,7 +6,7 @@
 """
 import datetime
 
-def xml_to_dict(root_or_str):
+def xml_to_dict(root_or_str, strict=False):
     """
     Converts `root_or_str` which can be parsed xml or a xml string to dict.
 
@@ -15,7 +15,7 @@ def xml_to_dict(root_or_str):
     if isinstance(root, str):
         import xml.etree.cElementTree as ElementTree
         root = ElementTree.XML(root_or_str)
-    return {root.tag: _from_xml(root)}
+    return {root.tag: _from_xml(root, strict)}
 
 def dict_to_xml(dict_xml):
     """
@@ -101,7 +101,7 @@ def _str_to_boolean(bool_str):
         return True
     return False
 
-def _from_xml(el):
+def _from_xml(el, strict=False):
     """
     Extracts value of xml element element `el`.
     """
@@ -109,18 +109,28 @@ def _from_xml(el):
     # Parent node.
     if el:
         if _is_xml_el_dict(el):
-            val = _dict_from_xml(el)
+            val = _dict_from_xml(el, strict)
         elif _is_xml_el_list(el):
-            val = _list_from_xml(el)
+            val = _list_from_xml(el, strict)
     # Simple node.
     else:
         attribs = el.items()
-        # An element with no subelements but text.
-        if el.text:
-            val = _val_and_maybe_convert(el)
         # An element with attributes.
+        if attribs and strict:
+            val = dict(attribs)
+            if strict:
+                val = dict([('@%s' % k,v) for k,v in val.items()])
+                if el.text:
+                    converted = _val_and_maybe_convert(el)
+                    val['#text'] = el.text
+                    if converted != el.text:
+                        val['#value'] = converted
+        elif el.text:
+            # An element with no subelements but text.
+            val = _val_and_maybe_convert(el)
         elif attribs:
             val = dict(attribs)
+
     return val
 
 def _val_and_maybe_convert(el):
@@ -140,22 +150,22 @@ _val_and_maybe_convert.convertors = {
     'integer': int
 }
 
-def _list_from_xml(els):
+def _list_from_xml(els, strict=False):
     """
     Converts xml elements list `el_list` to a python list.
     """
     res = []
     tag = els[0].tag
     for el in els:
-        res.append(_from_xml(el))
+        res.append(_from_xml(el, strict))
     return {tag: res}
 
-def _dict_from_xml(els):
+def _dict_from_xml(els, strict=False):
     """
     Converts xml doc with root `root` to a python dict.
     """
     # An element with subelements.
     res = {}
     for el in els:
-        res[el.tag] = _from_xml(el)
+        res[el.tag] = _from_xml(el, strict)
     return res


### PR DESCRIPTION
Hi, 

I've added a 'strict' parameter to xml_to_dict so that it returns output similar to the one described here: http://www.xml.com/pub/a/2006/05/31/converting-between-xml-and-json.html

dict_to_xml also have been updated so that it can generate full xml with attributes using the format.

thanks for the nice lib. 
