### PR TITLE
XML to dict symetric conversion

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -68,8 +68,6 @@ class TestXmlutils(unittest.TestCase):
 
     def test_xml_to_dict_and_reverse(self):
 
-        self.maxDiff = None
-
         test = '''<messages>
 <message id="1">
 a
@@ -100,15 +98,15 @@ d
 
         self.assertEqual(expected, xml_to_dict(test, strict=True))
 
-        # once converted to dict, go back to xml (ddo not care about extra blanks)
-        def _remove_spaces(content):
+        # once converted to dict, go back to xml (do not care about extra blanks)
+        def _remove_blanks(content):
 
             from lxml import etree
             parser = etree.XMLParser(remove_blank_text=True)
             elem = etree.XML(content, parser=parser)
             return etree.tostring(elem)
 
-        self.assertEqual(_remove_spaces(test), dict_to_xml(expected))
+        self.assertEqual(_remove_blanks(test), dict_to_xml(expected))
 
     def test_xml_to_dict_order(self):
         order1 = '<a><c>2</c><c>3</c><b>1</b></a>'

--- a/tests.py
+++ b/tests.py
@@ -70,31 +70,29 @@ class TestXmlutils(unittest.TestCase):
 
         self.maxDiff = None
 
-        test = '''
-        <messages>
-        <message id="1">
-        a
-        b
-        ...
-        </message>
-        <message id="2">
-        c
-        d
-        ...
-        </message>
-        </messages>
-        '''
+        test = '''<messages>
+<message id="1">
+a
+b
+...
+</message>
+<message id="2">
+c
+d
+...
+</message>
+</messages>'''
 
         expected = {'messages':
                      {'message':
                         [
                             {'@id': '1',
-                             '#value': 'a\n        b\n        ...',
-                             '#text': '\n        a\n        b\n        ...\n        ',
+                             '#value': 'a\nb\n...',
+                             '#text': '\na\nb\n...\n',
                             },
                             {'@id': '2',
-                             '#value': 'c\n        d\n        ...',
-                             '#text': '\n        c\n        d\n        ...\n        ',
+                             '#value': 'c\nd\n...',
+                             '#text': '\nc\nd\n...\n',
                             },
                         ]
                     }
@@ -102,8 +100,15 @@ class TestXmlutils(unittest.TestCase):
 
         self.assertEqual(expected, xml_to_dict(test, strict=True))
 
-        # once converted to dict, go back to xml
-        self.assertEqual(test, dict_to_xml(expected))
+        # once converted to dict, go back to xml (ddo not care about extra blanks)
+        def _remove_spaces(content):
+
+            from lxml import etree
+            parser = etree.XMLParser(remove_blank_text=True)
+            elem = etree.XML(content, parser=parser)
+            return etree.tostring(elem)
+
+        self.assertEqual(_remove_spaces(test), dict_to_xml(expected))
 
     def test_xml_to_dict_order(self):
         order1 = '<a><c>2</c><c>3</c><b>1</b></a>'

--- a/tests.py
+++ b/tests.py
@@ -66,6 +66,44 @@ class TestXmlutils(unittest.TestCase):
 
         self.assertEqual(expected, xml_to_dict(test, strict=True))
 
+    def test_xml_to_dict_and_reverse(self):
+
+        self.maxDiff = None
+
+        test = '''
+        <messages>
+        <message id="1">
+        a
+        b
+        ...
+        </message>
+        <message id="2">
+        c
+        d
+        ...
+        </message>
+        </messages>
+        '''
+
+        expected = {'messages':
+                     {'message':
+                        [
+                            {'@id': '1',
+                             '#value': 'a\n        b\n        ...',
+                             '#text': '\n        a\n        b\n        ...\n        ',
+                            },
+                            {'@id': '2',
+                             '#value': 'c\n        d\n        ...',
+                             '#text': '\n        c\n        d\n        ...\n        ',
+                            },
+                        ]
+                    }
+                  }
+
+        self.assertEqual(expected, xml_to_dict(test, strict=True))
+
+        # once converted to dict, go back to xml
+        self.assertEqual(test, dict_to_xml(expected))
 
     def test_xml_to_dict_order(self):
         order1 = '<a><c>2</c><c>3</c><b>1</b></a>'

--- a/xmldict.py
+++ b/xmldict.py
@@ -61,7 +61,6 @@ def _dict_to_xml(els):
         return '<%s%s>%s%s</%s>' % (tag, attrs, _to_xml(content), text, tag)
 
     tags = []
-
     for tag, content in els.iteritems():
         # Text and attributes
         if tag.startswith('@') or tag == '#text' or tag == '#value':

--- a/xmldict.py
+++ b/xmldict.py
@@ -61,9 +61,10 @@ def _dict_to_xml(els):
         return '<%s%s>%s%s</%s>' % (tag, attrs, _to_xml(content), text, tag)
 
     tags = []
+
     for tag, content in els.iteritems():
         # Text and attributes
-        if tag.startswith('@') or tag == '#text':
+        if tag.startswith('@') or tag == '#text' or tag == '#value':
             continue
         elif isinstance(content, list):
             for el in content:


### PR DESCRIPTION
One would expect that converting XML to dict and converting this dict back to XML restores the initial XML file. Extra <#value>...</#value> are inserted.

This pull request adds a test case that reproduces the issue.
